### PR TITLE
Add stacklevel argument to findCaller()

### DIFF
--- a/logging_exceptions.py
+++ b/logging_exceptions.py
@@ -63,7 +63,7 @@ class ExlogLogger(logging.Logger):
         super(ExlogLogger, self).__init__(name, level)
         self.ignored_functions = []
 
-    def findCaller(self, stack_info=False):
+    def findCaller(self, stack_info=False, stacklevel=1):
         """
         Modified copy of the original logging.Logger.findCaller function.
 


### PR DESCRIPTION
The following code
```python
import logging
import logging_exceptions

logging.basicConfig()
logger = logging.getLogger('test')
logger.setLevel(logging.INFO)

logger.info('Test')
```

throws an error in Python 3.8

```
TypeError: findCaller() takes from 1 to 2 positional arguments but 3 were given
```

A new argument called stacklevel [was added](https://stackoverflow.com/a/64835190/14425096) in ``findCaller()`` function in Python 3.8. 